### PR TITLE
Add platform data to My Plugins dropdown 

### DIFF
--- a/views/templates/navigation.ejs
+++ b/views/templates/navigation.ejs
@@ -57,7 +57,7 @@
         <li><a class="subheader"><i class="material-icons left" style="font-size: 30px">content_paste</i>My Plugins</a>
         </li>
         <% for (var i = 0; i < myPlugins.length; i++) { %>
-        <li><a class="waves-effect truncate" href="/plugin/<%= myPlugins[i].software.url %>/<%= myPlugins[i].name %>"><%= myPlugins[i].name %></a></li>
+        <li><a class="waves-effect truncate" href="/plugin/<%= myPlugins[i].software.url %>/<%= myPlugins[i].name %>"><%= myPlugins[i].name %> (<%= myPlugins[i].software.name %>)</a></li>
         <% } %>
     </div>
     <% } %>
@@ -73,7 +73,7 @@
 <ul id="dropdownMyPlugins" class="dropdown-content">
     <% if (loggedIn) { %>
     <% for (var i = 0; i < myPlugins.length; i++) { %>
-    <li><a href="/plugin/<%= myPlugins[i].software.url %>/<%= myPlugins[i].name %>" class="truncate <%= customColor1 %>-text"><%= myPlugins[i].name %></a></li>
+    <li><a href="/plugin/<%= myPlugins[i].software.url %>/<%= myPlugins[i].name %>" class="truncate <%= customColor1 %>-text"><%= myPlugins[i].name %> (<%= myPlugins[i].software.name %>)</a></li>
     <% } %>
     <% } %>
 </ul>

--- a/views/templates/navigation.ejs
+++ b/views/templates/navigation.ejs
@@ -113,7 +113,7 @@
             <li><a href="/add-plugin">
                     <i class="material-icons left" style="font-size: 30px">add</i>Add plugin
                 </a></li>
-            <li><a class="dropdown-button" href="#!" data-beloworigin="true" data-hover="true" data-activates="dropdownMyPlugins">
+            <li><a class="dropdown-button" href="#!" data-beloworigin="true" data-constrainwidth="false" data-hover="true" data-activates="dropdownMyPlugins">
                     <i class="material-icons left" style="margin-right: 0px; font-size: 30px">arrow_drop_down</i>My Plugins
                 </a></li>
             <% } else if (loggedIn) { %>


### PR DESCRIPTION
This happens when you add plugins that support multiple platforms:

![image](https://user-images.githubusercontent.com/6520738/50846999-772f4f00-133e-11e9-85db-b1a4c099f346.png)

To address this, it might be a good idea to specify what the platform is in the dropdown menu so that users can at least click on the correct option.