### PR TITLE
Add Tuinity and Purpur software versions

### DIFF
--- a/routes/submitData.js
+++ b/routes/submitData.js
@@ -284,6 +284,10 @@ router.post('/:software?', function(request, response, next) {
                                 software = 'Lava';
                             } else if (bukkitVersion2.indexOf('mohist') !== -1) {
                                 software = 'Mohist';
+                            } else if (bukkitVersion2.indexOf('tuinity') !== -1) {
+                                software = 'Tuinity';
+                            } else if (bukkitVersion2.indexOf('purpur') !== -1) {
+                                software = 'Purpur';
                             }
 
                             defaultGlobalCharts.push({


### PR DESCRIPTION
These are popular forks of Paper run by well known developers, which I was looking to track in bStats.
Purpur is a fork of Tuinity which is a fork of Paper.

As of writing there are ~250 servers using Purpur, and Tuinity doesn't use bStats itself but the number is likely much higher.
https://bstats.org/plugin/server-implementation/Purpur/5103

Thanks 😄 
